### PR TITLE
add functionality to db api

### DIFF
--- a/Buchungstrainer/src/interfaces.ts
+++ b/Buchungstrainer/src/interfaces.ts
@@ -1,6 +1,6 @@
 export interface Assignment {
     // "id" will not work due to the DB
-    key: string;
+    key?: string;
     authorId: string;
     title: string;
     description: string;

--- a/Buchungstrainer/src/lib/database/deleteAssignment.ts
+++ b/Buchungstrainer/src/lib/database/deleteAssignment.ts
@@ -1,0 +1,5 @@
+import assignmentDb from "./assignmentDb";
+
+export default async function deleteAssignment(key: string): Promise<null> {
+    return await assignmentDb.delete(key);
+}

--- a/Buchungstrainer/src/lib/database/insertAssignments.ts
+++ b/Buchungstrainer/src/lib/database/insertAssignments.ts
@@ -1,0 +1,7 @@
+import type { Assignment } from "$interfaces";
+import type { ObjectType } from "deta/dist/types/types/basic";
+import assignmentDb from "./assignmentDb";
+
+export default async function insertAssignments(content: Assignment): Promise<ObjectType> {
+    return assignmentDb.insert(content as unknown as ObjectType);
+}

--- a/Buchungstrainer/src/lib/database/insertAssignments.ts
+++ b/Buchungstrainer/src/lib/database/insertAssignments.ts
@@ -2,6 +2,6 @@ import type { Assignment } from "$interfaces";
 import type { ObjectType } from "deta/dist/types/types/basic";
 import assignmentDb from "./assignmentDb";
 
-export default async function insertAssignments(content: Assignment): Promise<ObjectType> {
-    return assignmentDb.insert(content as unknown as ObjectType);
+export default async function insertAssignments(assignment: Assignment): Promise<ObjectType> {
+    return assignmentDb.insert(assignment as unknown as ObjectType);
 }

--- a/Buchungstrainer/src/lib/database/updateAssignment.ts
+++ b/Buchungstrainer/src/lib/database/updateAssignment.ts
@@ -1,0 +1,11 @@
+import type { Assignment } from "$interfaces";
+import type { ObjectType } from "deta/dist/types/types/basic";
+import assignmentDb from "./assignmentDb";
+
+export default async function updateAssignment(assignment: Assignment): Promise<void> {
+    if (!assignment.key) {
+        throw new Error("Assignment has no key. Please use insertAssignment instead.");
+    }
+
+    await assignmentDb.update(assignment as unknown as ObjectType, assignment.key);
+}


### PR DESCRIPTION
- make assignment key nullable The key has to be nullable for inserts on the database. This way the database will automatically assign a key to it on insertion
- implement assignment insertion functions
- add assignment deletion function
- add function to update assignments
- rename parameter for readability
