### PR TITLE
Fix adapter and envrionmnet variables

### DIFF
--- a/Buchungstrainer/package-lock.json
+++ b/Buchungstrainer/package-lock.json
@@ -15,6 +15,7 @@
             },
             "devDependencies": {
                 "@sveltejs/adapter-auto": "^2.0.0",
+                "@sveltejs/adapter-node": "^1.3.1",
                 "@sveltejs/kit": "^1.27.4",
                 "@typescript-eslint/eslint-plugin": "^6.0.0",
                 "@typescript-eslint/parser": "^6.0.0",
@@ -251,6 +252,159 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@rollup/plugin-commonjs": {
+            "version": "25.0.7",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+            "integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "glob": "^8.0.3",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/is-reference": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+            "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
+        "node_modules/@rollup/plugin-commonjs/node_modules/minimatch": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@rollup/plugin-json": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+            "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "15.2.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+            "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-builtin-module": "^3.2.1",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.78.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+            "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+            "dev": true,
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
             "dev": true,
@@ -262,6 +416,21 @@
             "license": "MIT",
             "dependencies": {
                 "import-meta-resolve": "^4.0.0"
+            },
+            "peerDependencies": {
+                "@sveltejs/kit": "^1.0.0"
+            }
+        },
+        "node_modules/@sveltejs/adapter-node": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.3.1.tgz",
+            "integrity": "sha512-A0VgRQDCDPzdLNoiAbcOxGw4zT1Mc+n1LwT1OmO350R7WxrEqdMUChPPOd1iMfIDWlP4ie6E2d/WQf5es2d4Zw==",
+            "dev": true,
+            "dependencies": {
+                "@rollup/plugin-commonjs": "^25.0.0",
+                "@rollup/plugin-json": "^6.0.0",
+                "@rollup/plugin-node-resolve": "^15.0.1",
+                "rollup": "^3.7.0"
             },
             "peerDependencies": {
                 "@sveltejs/kit": "^1.0.0"
@@ -379,6 +548,12 @@
             "version": "2.0.9",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+            "dev": true
         },
         "node_modules/@types/semver": {
             "version": "7.5.5",
@@ -813,6 +988,18 @@
                 "node": "*"
             }
         },
+        "node_modules/builtin-modules": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+            "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/cac": {
             "version": "6.7.14",
             "dev": true,
@@ -936,6 +1123,12 @@
             "version": "1.1.4",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+            "dev": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -1449,6 +1642,15 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-func-name": {
             "version": "2.0.2",
             "dev": true,
@@ -1548,6 +1750,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dev": true,
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.2.4",
             "dev": true,
@@ -1613,6 +1827,33 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-builtin-module": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+            "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+            "dev": true,
+            "dependencies": {
+                "builtin-modules": "^3.3.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+            "dev": true,
+            "dependencies": {
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "dev": true,
@@ -1631,6 +1872,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true
         },
         "node_modules/is-number": {
             "version": "7.0.0",
@@ -2029,6 +2276,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "dev": true,
@@ -2291,6 +2544,23 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/resolve": {
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "dev": true,
+            "dependencies": {
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "dev": true,
@@ -2541,6 +2811,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/svelte": {

--- a/Buchungstrainer/package.json
+++ b/Buchungstrainer/package.json
@@ -15,6 +15,7 @@
     },
     "devDependencies": {
         "@sveltejs/adapter-auto": "^2.0.0",
+        "@sveltejs/adapter-node": "^1.3.1",
         "@sveltejs/kit": "^1.27.4",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",

--- a/Buchungstrainer/src/lib/database/assignmentDb.ts
+++ b/Buchungstrainer/src/lib/database/assignmentDb.ts
@@ -1,6 +1,7 @@
 import { Deta } from "deta";
 
-const deta = Deta();
-const assignmentDb = deta.Base("assignments");
-
-export default assignmentDb;
+export default function assignmentDb() {
+    const deta = Deta();
+    const assignmentDb = deta.Base("assignments");
+    return assignmentDb;
+}

--- a/Buchungstrainer/src/lib/database/deleteAssignment.ts
+++ b/Buchungstrainer/src/lib/database/deleteAssignment.ts
@@ -1,5 +1,5 @@
 import assignmentDb from "./assignmentDb";
 
 export default async function deleteAssignment(key: string): Promise<null> {
-    return await assignmentDb.delete(key);
+    return await assignmentDb().delete(key);
 }

--- a/Buchungstrainer/src/lib/database/getAssignmentByKey.ts
+++ b/Buchungstrainer/src/lib/database/getAssignmentByKey.ts
@@ -2,7 +2,7 @@ import type { Assignment } from "$interfaces";
 import assignmentDb from "./assignmentDb";
 
 export default async function getAssignmentByKey(key: string): Promise<Assignment> {
-    const response = await assignmentDb.get(key);
+    const response = await assignmentDb().get(key);
 
     if (!response) {
         throw new Error("Failed to fetch assignments");

--- a/Buchungstrainer/src/lib/database/getAssignments.ts
+++ b/Buchungstrainer/src/lib/database/getAssignments.ts
@@ -2,7 +2,7 @@ import type { Assignment } from "$interfaces";
 import assignmentDb from "./assignmentDb";
 
 export default async function getAssignments(): Promise<Assignment[]> {
-    const response = await assignmentDb.fetch();
+    const response = await assignmentDb().fetch();
 
     if (!response) {
         throw new Error("Failed to fetch assignments");

--- a/Buchungstrainer/src/lib/database/insertAssignments.ts
+++ b/Buchungstrainer/src/lib/database/insertAssignments.ts
@@ -3,5 +3,5 @@ import type { ObjectType } from "deta/dist/types/types/basic";
 import assignmentDb from "./assignmentDb";
 
 export default async function insertAssignments(assignment: Assignment): Promise<ObjectType> {
-    return assignmentDb.insert(assignment as unknown as ObjectType);
+    return assignmentDb().insert(assignment as unknown as ObjectType);
 }

--- a/Buchungstrainer/src/lib/database/updateAssignment.ts
+++ b/Buchungstrainer/src/lib/database/updateAssignment.ts
@@ -7,5 +7,5 @@ export default async function updateAssignment(assignment: Assignment): Promise<
         throw new Error("Assignment has no key. Please use insertAssignment instead.");
     }
 
-    await assignmentDb.update(assignment as unknown as ObjectType, assignment.key);
+    await assignmentDb().update(assignment as unknown as ObjectType, assignment.key);
 }

--- a/Buchungstrainer/src/lib/services/auth.ts
+++ b/Buchungstrainer/src/lib/services/auth.ts
@@ -1,11 +1,11 @@
-import { PUBLIC_DOMAIN, PUBLIC_AUTH0_CLIENT_ID } from "$env/static/public";
+import { env } from "$env/dynamic/public";
 import { isAuthenticated, popupOpen, user } from "$lib/stores/auth";
 import { type Auth0Client, createAuth0Client, type PopupLoginOptions } from "@auth0/auth0-spa-js";
 
 async function createClient() {
     const auth0Client = await createAuth0Client({
-        domain: PUBLIC_DOMAIN || "",
-        clientId: PUBLIC_AUTH0_CLIENT_ID || ""
+        domain: env.PUBLIC_DOMAIN || "",
+        clientId: env.PUBLIC_AUTH0_CLIENT_ID || ""
     });
 
     return auth0Client;

--- a/Buchungstrainer/svelte.config.js
+++ b/Buchungstrainer/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from "@sveltejs/adapter-auto";
+import adapter from "@sveltejs/adapter-node";
 
 import { vitePreprocess } from "@sveltejs/kit/vite";
 


### PR DESCRIPTION
- update import to node
- install older version of node adapter
- make env vars dynamic
- move Deta() into function from top level

I had to change all of the static env-vars to dynamic. This way the compiler would not try to replace them with their values during build time. Svelte-Kit attempts to prerender pages in that phase. However, the Deta Builder Instance does not let the app access env-vars during build time, only during runtime. This rose an error when trying to fetch inexistent values from the builder session.

The way I initialised and exported the database also turned out to be an issue. That could be solved by moving the logic into a separate factory-function and exporting it (instead of just passing a pointer to the db-instance value).
An error was raised when the Deta() function was called on top level during build time. That function uses an env-var, which is set by the cloud- and the dev-env during runtime. That is why it had to be wrapped in a different function.

In the future, I might turn it into a singleton, but that is not required as of right now and would possibly complicate things.